### PR TITLE
Don't set an enterprise `openshift_deployment_type`

### DIFF
--- a/playbooks/roles/cluster-variables/vars/main.yaml
+++ b/playbooks/roles/cluster-variables/vars/main.yaml
@@ -17,7 +17,7 @@ openshift_master_cluster_hostname: "internal-openshift-master.{{ public_hosted_z
 openshift_master_cluster_public_hostname: "openshift-master.{{ public_hosted_zone }}"
 openshift_master_default_subdomain: "{{ wildcard_zone }}"
 osm_default_node_selector: "role=app"
-openshift_deployment_type: openshift-enterprise
+openshift_deployment_type: origin 
 openshift_master_identity_providers:
 - name: google
   kind: GoogleIdentityProvider


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>