### PR TITLE
Add HAProxy metrics port to internal firewall

### DIFF
--- a/playbooks/roles/provision/templates/provision.j2.sh
+++ b/playbooks/roles/provision/templates/provision.j2.sh
@@ -80,10 +80,10 @@ declare -A FW_RULES=(
   ['icmp']='--allow icmp'
   ['ssh-external']='--allow tcp:22'
   ['ssh-internal']='--allow tcp:22 --source-tags bastion'
-  ['master-internal']="--allow tcp:2224,tcp:2379,tcp:2380,tcp:4001,udp:4789,udp:5404,udp:5405,tcp:8053,udp:8053,tcp:8444,tcp:10250,tcp:10255,udp:10255,tcp:24224,udp:24224 --source-tags ocp --target-tags ocp-master"
+  ['master-internal']="--allow tcp:1935,tcp:2224,tcp:2379,tcp:2380,tcp:4001,udp:4789,udp:5404,udp:5405,tcp:8053,udp:8053,tcp:8444,tcp:10250,tcp:10255,udp:10255,tcp:24224,udp:24224 --source-tags ocp --target-tags ocp-master"
   ['master-external']="--allow tcp:80,tcp:443,tcp:1936,tcp:8080,tcp:8443${range} --target-tags ocp-master"
-  ['node-internal']="--allow udp:4789,tcp:10250,tcp:10255,udp:10255 --source-tags ocp --target-tags ocp-node,ocp-infra-node"
-  ['infra-node-internal']="--allow tcp:5000 --source-tags ocp --target-tags ocp-infra-node"
+  ['node-internal']="--allow tcp:1935,udp:4789,tcp:10250,tcp:10255,udp:10255 --source-tags ocp --target-tags ocp-node,ocp-infra-node"
+  ['infra-node-internal']="--allow tcp:1935,tcp:5000 --source-tags ocp --target-tags ocp-infra-node"
   ['infra-node-external']="--allow tcp:80,tcp:443,tcp:1936${range} --target-tags ocp-infra-node"
 )
 


### PR DESCRIPTION
HAProxy listens on the host network, but prometheus gathers from the pod network. If pod network can't reach 1935 we can't gather metrics