### PR TITLE
Router and registry are being created with invalid selectors

### DIFF
--- a/inventory/group_vars/all/00_defaults.yaml
+++ b/inventory/group_vars/all/00_defaults.yaml
@@ -10,14 +10,13 @@ openshift_master_console_port: "{{ console_port }}"
 osm_cluster_network_cidr: 172.16.0.0/16
 osm_host_subnet_length: 9
 openshift_portal_net: 172.30.0.0/16
-openshift_registry_selector: "role=infra"
-openshift_router_selector: "role=infra"
 openshift_hosted_router_replicas: 2
 openshift_hosted_registry_replicas: 2
 openshift_master_cluster_method: native
 openshift_master_cluster_hostname: "internal-openshift-master.{{ public_hosted_zone }}"
 openshift_master_cluster_public_hostname: "openshift-master.{{ public_hosted_zone }}"
 openshift_master_default_subdomain: "{{ wildcard_zone }}"
+openshift_hosted_infra_selector: "role=infra"
 osm_default_node_selector: "role=app"
 openshift_deployment_type: origin 
 openshift_hosted_registry_storage_provider: gcs


### PR DESCRIPTION
Cluster was deployed with role=infra/app, the very old selector values look to now be ignored and so were choosing region=infra (the new default).  Removing the old values.