### PR TITLE
Fix image playbook and add reqs for openshift/release PR #97

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,12 @@ FROM openshift/origin-base
 LABEL io.k8s.display-name="OpenShift GCE Install Environment" \
       io.k8s.description="This image helps install OpenShift onto GCE."
 
+ARG OPENSHIFT_ANSIBLE_REPO=https://github.com/openshift/openshift-ansible.git
+ARG OPENSHIFT_ANSIBLE_TAG=master
+
 ENV WORK=/usr/share/ansible/openshift-ansible-gce \
     HOME=/home/cloud-user \
     GOOGLE_CLOUD_SDK_VERSION=147.0.0 \
-    OPENSHIFT_ANSIBLE_TAG=master \
     ANSIBLE_JUNIT_DIR=/tmp/openshift/ansible_junit
 
 # meta refresh_inventory has a bug in 2.2.0 where it uses relative path
@@ -50,7 +52,7 @@ RUN mkdir -p /usr/share/ansible $HOME/.ssh $WORK/playbooks/files && \
     yum install -y ansible && \
     yum clean all && \
     cd /usr/share/ansible && \
-    git clone https://github.com/openshift/openshift-ansible.git && \
+    git clone ${OPENSHIFT_ANSIBLE_REPO} && \
     cd openshift-ansible && \
     git checkout ${OPENSHIFT_ANSIBLE_TAG} && \
     cd $HOME && \

--- a/playbooks/image.yaml
+++ b/playbooks/image.yaml
@@ -73,6 +73,25 @@
         repo_gpgcheck: yes
         state: present
       when: ansible_os_family == "RedHat"
+    - name: Add the jdetiber-qemu-user-static copr repo
+      yum_repository:
+        name: jdetiber-qemu-user-static
+        description: QEMU user static COPR
+        baseurl: https://copr-be.cloud.fedoraproject.org/results/jdetiber/qemu-user-static/epel-7-$basearch/
+        gpgkey: https://copr-be.cloud.fedoraproject.org/results/jdetiber/qemu-user-static/pubkey.gpg
+        gpgcheck: yes
+        repo_gpgcheck: no
+        state: present
+      when: ansible_os_family == "RedHat"
+    - name: Install qemu-user-static
+      package:
+        name: qemu-user-static
+        state: present
+    - name: Start and enable systemd-binfmt service
+      systemd:
+        name: systemd-binfmt
+        state: started
+        enabled: yes
 
 - name: Build image
   hosts: build_instance_ips

--- a/playbooks/image.yaml
+++ b/playbooks/image.yaml
@@ -7,8 +7,8 @@
   tasks:
     - name: Create the image instance disk
       gce_pd:
-        service_account_email: "{{ (lookup('file', playbook_dir + '/files/' + gce_service_account_keyfile ) | from_json ).client_email }}"
-        credentials_file: "{{ playbook_dir + '/files/' + gce_service_account_keyfile }}"
+        service_account_email: "{{ (lookup('file', gce_service_account_keyfile ) | from_json ).client_email }}"
+        credentials_file: "{{ gce_service_account_keyfile }}"
         project_id: "{{ gce_project_id }}"
         zone: "{{ gce_zone_name }}"
         name: "{{ provision_prefix }}build-image-instance"
@@ -19,8 +19,8 @@
 
     - name: Launch the image build instance
       gce:
-        service_account_email: "{{ (lookup('file', playbook_dir + '/files/' + gce_service_account_keyfile ) | from_json ).client_email }}"
-        credentials_file: "{{ playbook_dir + '/files/' + gce_service_account_keyfile }}"
+        service_account_email: "{{ (lookup('file', gce_service_account_keyfile ) | from_json ).client_email }}"
+        credentials_file: "{{ gce_service_account_keyfile }}"
         project_id: "{{ gce_project_id }}"
         zone: "{{ gce_zone_name }}"
         machine_type: n1-standard-1
@@ -50,7 +50,7 @@
 - name: Prepare instance content sources
   pre_tasks:
   - set_fact:
-      allow_rhel_subscriptions: "{{ lookup('oo_option', 'rhel_skip_subscription') | default(rhsub_skip, True) | default('no', True) | lower in ['no', 'false'] }}"
+      allow_rhel_subscriptions: "{{ rhsub_skip | default('no', True) | lower in ['no', 'false'] }}"
   - set_fact:
       using_rhel_subscriptions: "{{ (deployment_type in ['enterprise', 'atomic-enterprise', 'openshift-enterprise'] or ansible_distribution == 'RedHat') and allow_rhel_subscriptions }}"
   hosts: build_instance_ips
@@ -112,8 +112,8 @@
   tasks:
     - name: Terminate the image build instance
       gce:
-        service_account_email: "{{ (lookup('file', playbook_dir + '/files/' + gce_service_account_keyfile ) | from_json ).client_email }}"
-        credentials_file: "{{ playbook_dir + '/files/' + gce_service_account_keyfile }}"
+        service_account_email: "{{ (lookup('file', gce_service_account_keyfile ) | from_json ).client_email }}"
+        credentials_file: "{{ gce_service_account_keyfile }}"
         project_id: "{{ gce_project_id }}"
         zone: "{{ gce_zone_name }}"
         instance_names: "{{ provision_prefix }}build-image-instance"
@@ -122,8 +122,8 @@
       command: gcloud --project "{{ gce_project_id}}" compute images create "{{ provision_gce_registered_image_id | default(provision_gce_registered_image + '-' + lookup('pipe','date +%Y%m%d-%H%M%S')) }}" --source-disk "{{ provision_prefix }}build-image-instance" --source-disk-zone "{{ gce_zone_name }}" --family "{{ provision_gce_registered_image }}"
     - name: Remove the image instance disk
       gce_pd:
-        service_account_email: "{{ (lookup('file', playbook_dir + '/files/' + gce_service_account_keyfile ) | from_json ).client_email }}"
-        credentials_file: "{{ playbook_dir + '/files/' + gce_service_account_keyfile }}"
+        service_account_email: "{{ (lookup('file', gce_service_account_keyfile ) | from_json ).client_email }}"
+        credentials_file: "{{ gce_service_account_keyfile }}"
         project_id: "{{ gce_project_id }}"
         zone: "{{ gce_zone_name }}"
         name: "{{ provision_prefix }}build-image-instance"

--- a/playbooks/roles/custom-repositories/tasks/main.yaml
+++ b/playbooks/roles/custom-repositories/tasks/main.yaml
@@ -2,13 +2,13 @@
   copy:
     src: "{{ playbook_dir }}/files/{{ item.1.sslclientcert }}"
     dest: /var/lib/yum/custom_secret_{{ item.0 }}_cert
-  when: item.1.sslclientcert
+  when: item.1.sslclientcert | default(false)
   with_indexed_items: "{{ provision_custom_repositories }}"
 - name: Copy custom repository secrets
   copy:
     src: "{{ playbook_dir }}/files/{{ item.1.sslclientkey }}"
     dest: /var/lib/yum/custom_secret_{{ item.0 }}_key
-  when: item.1.sslclientkey
+  when: item.1.sslclientkey | default(false)
   with_indexed_items: "{{ provision_custom_repositories }}"
 
 - name: Create any custom repos that are defined

--- a/playbooks/roles/custom-repositories/templates/yum_repo.j2
+++ b/playbooks/roles/custom-repositories/templates/yum_repo.j2
@@ -6,8 +6,12 @@ baseurl={{ repo.baseurl }}
 enabled={{ 1 if ( enable_repo == 1 or enable_repo == True ) else 0 }}
 {% set enable_gpg_check = repo.gpgcheck | default(1) %}
 gpgcheck={{ 1 if ( enable_gpg_check == 1 or enable_gpg_check == True ) else 0 }}
+{% if 'sslclientcert' in repo %}
 sslclientcert={{ "/var/lib/yum/custom_secret_" + (loop.index-1)|string + "_cert" if repo.sslclientcert }}
+{% endif %}
+{% if 'sslclientkey' in repo %}
 sslclientkey={{ "/var/lib/yum/custom_secret_" + (loop.index-1)|string + "_key" if repo.sslclientkey }}
+{% endif %}
 {% for key, value in repo.iteritems() %}
 {% if key not in ['id', 'name', 'baseurl', 'enabled', 'gpgcheck', 'sslclientkey', 'sslclientcert'] and value is defined %}
 {{ key }}={{ value }}

--- a/playbooks/roles/openshift-roles/tasks/main.yaml
+++ b/playbooks/roles/openshift-roles/tasks/main.yaml
@@ -1,4 +1,9 @@
 ---
 - name: Assign roles to cluster users
   command: oadm policy add-cluster-role-to-user "{{ item.role }}" "{{ item.user }}"
+  when: "'user' in item"
+  with_items: "{{ provision_role_mappings | default([]) }}"
+- name: Assign roles to cluster groups
+  command: oadm policy add-cluster-role-to-group "{{ item.role }}" "{{ item.group }}"
+  when: "'group' in item"
   with_items: "{{ provision_role_mappings | default([]) }}"


### PR DESCRIPTION
- Updates to fix image playbook after previous refactorings and updates to openshift-ansible
- Reqs for https://github.com/openshift/release/pull/97
  - Add qemu-user-static when creating image
  - Enable systemd-binfmt service when creating image
  - Add support for setting cluster group mappings