### PR TITLE
Prepare for building bootstrap images on GCP

### DIFF
--- a/playbooks/build_base_image.yaml
+++ b/playbooks/build_base_image.yaml
@@ -5,15 +5,20 @@
   connection: local
   gather_facts: no
   tasks:
+    - name: Require openshift_gcp_root_image
+      fail:
+        msg: "A root OS image name or family is required for base image building.  Please ensure `openshift_gcp_root_image` is defined."
+      when: openshift_gcp_root_image is undefined
+
     - name: Create the image instance disk
       gce_pd:
-        service_account_email: "{{ (lookup('file', gce_service_account_keyfile ) | from_json ).client_email }}"
-        credentials_file: "{{ gce_service_account_keyfile }}"
-        project_id: "{{ gce_project_id }}"
-        zone: "{{ gce_zone_name }}"
-        name: "{{ provision_prefix }}build-image-instance"
+        service_account_email: "{{ (lookup('file', openshift_gcp_iam_service_account_keyfile ) | from_json ).client_email }}"
+        credentials_file: "{{ openshift_gcp_iam_service_account_keyfile }}"
+        project_id: "{{ openshift_gcp_project }}"
+        zone: "{{ openshift_gcp_zone }}"
+        name: "{{ openshift_gcp_prefix }}build-image-instance"
         disk_type: pd-ssd
-        image: "{{ provision_gce_base_image | default('https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-7-v20170110') }}"
+        image: "{{ openshift_gcp_root_image }}"
         size_gb: 10
         state: present
 
@@ -21,16 +26,16 @@
       gce:
         service_account_email: "{{ (lookup('file', gce_service_account_keyfile ) | from_json ).client_email }}"
         credentials_file: "{{ gce_service_account_keyfile }}"
-        project_id: "{{ gce_project_id }}"
-        zone: "{{ gce_zone_name }}"
+        project_id: "{{ openshift_gcp_project }}"
+        zone: "{{ openshift_gcp_zone }}"
         machine_type: n1-standard-1
-        instance_names: "{{ provision_prefix }}build-image-instance"
+        instance_names: "{{ openshift_gcp_prefix }}build-image-instance"
         state: present
         tags:
           - build-image-instance
         disk_auto_delete: false
         disks:
-          - "{{ provision_prefix }}build-image-instance"
+          - "{{ openshift_gcp_prefix }}build-image-instance"
       register: gce
 
     - add_host:
@@ -131,19 +136,19 @@
   tasks:
     - name: Terminate the image build instance
       gce:
-        service_account_email: "{{ (lookup('file', gce_service_account_keyfile ) | from_json ).client_email }}"
-        credentials_file: "{{ gce_service_account_keyfile }}"
-        project_id: "{{ gce_project_id }}"
-        zone: "{{ gce_zone_name }}"
-        instance_names: "{{ provision_prefix }}build-image-instance"
+        service_account_email: "{{ (lookup('file', openshift_gcp_iam_service_account_keyfile ) | from_json ).client_email }}"
+        credentials_file: "{{ openshift_gcp_iam_service_account_keyfile }}"
+        project_id: "{{ openshift_gcp_project }}"
+        zone: "{{ openshift_gcp_zone }}"
+        instance_names: "{{ openshift_gcp_prefix }}build-image-instance"
         state: absent
     - name: Save the new image
-      command: gcloud --project "{{ gce_project_id}}" compute images create "{{ provision_gce_registered_image_id | default(provision_gce_registered_image + '-' + lookup('pipe','date +%Y%m%d-%H%M%S')) }}" --source-disk "{{ provision_prefix }}build-image-instance" --source-disk-zone "{{ gce_zone_name }}" --family "{{ provision_gce_registered_image }}"
+      command: gcloud --project "{{ openshift_gcp_project}}" compute images create "{{ openshift_gcp_base_image_name | default(openshift_gcp_base_image + '-' + lookup('pipe','date +%Y%m%d-%H%M%S')) }}" --source-disk "{{ openshift_gcp_prefix }}build-image-instance" --source-disk-zone "{{ openshift_gcp_zone }}" --family "{{ openshift_gcp_base_image }}"
     - name: Remove the image instance disk
       gce_pd:
-        service_account_email: "{{ (lookup('file', gce_service_account_keyfile ) | from_json ).client_email }}"
-        credentials_file: "{{ gce_service_account_keyfile }}"
-        project_id: "{{ gce_project_id }}"
-        zone: "{{ gce_zone_name }}"
-        name: "{{ provision_prefix }}build-image-instance"
+        service_account_email: "{{ (lookup('file', openshift_gcp_iam_service_account_keyfile ) | from_json ).client_email }}"
+        credentials_file: "{{ openshift_gcp_iam_service_account_keyfile }}"
+        project_id: "{{ openshift_gcp_project }}"
+        zone: "{{ openshift_gcp_zone }}"
+        name: "{{ openshift_gcp_prefix }}build-image-instance"
         state: absent

--- a/playbooks/build_image.yaml
+++ b/playbooks/build_image.yaml
@@ -1,0 +1,105 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - name: Require openshift_gcp_base_image
+    fail:
+      msg: "A base image name or family is required for image building.  Please ensure `openshift_gcp_base_image` is defined."
+    when: openshift_gcp_base_image is undefined
+
+- name: Launch image build instance
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+    - name: Set facts
+      set_fact:
+        openshift_node_bootstrap: True
+
+    - name: Create the image instance disk
+      gce_pd:
+        service_account_email: "{{ (lookup('file', openshift_gcp_iam_service_account_keyfile ) | from_json ).client_email }}"
+        credentials_file: "{{ openshift_gcp_iam_service_account_keyfile }}"
+        project_id: "{{ openshift_gcp_project }}"
+        zone: "{{ openshift_gcp_zone }}"
+        name: "{{ openshift_gcp_prefix }}build-image-instance"
+        disk_type: pd-ssd
+        image: "{{ openshift_gcp_base_image }}"
+        size_gb: 10
+        state: present
+
+    - name: Launch the image build instance
+      gce:
+        service_account_email: "{{ (lookup('file', gce_service_account_keyfile ) | from_json ).client_email }}"
+        credentials_file: "{{ gce_service_account_keyfile }}"
+        project_id: "{{ openshift_gcp_project }}"
+        zone: "{{ openshift_gcp_zone }}"
+        machine_type: n1-standard-1
+        instance_names: "{{ openshift_gcp_prefix }}build-image-instance"
+        state: present
+        tags:
+          - build-image-instance
+        disk_auto_delete: false
+        disks:
+          - "{{ openshift_gcp_prefix }}build-image-instance"
+      register: gce
+
+    - name: add host to nodes
+      add_host:
+        hostname: "{{ item.public_ip }}"
+        groupname: nodes
+      with_items: "{{ gce.instance_data }}"
+
+    - name: Wait for instance to respond to SSH
+      wait_for:
+        delay: 1
+        host: "{{ item.public_ip }}"
+        port: 22
+        state: started
+        timeout: 120
+      with_items: "{{ gce.instance_data }}"
+
+- name: normalize groups
+  include: /usr/share/ansible/openshift-ansible/playbooks/byo/openshift-cluster/initialize_groups.yml
+
+- name: run the std_include
+  include: /usr/share/ansible/openshift-ansible/playbooks/common/openshift-cluster/evaluate_groups.yml
+
+- name: run the std_include
+  include: /usr/share/ansible/openshift-ansible/playbooks/common/openshift-cluster/initialize_facts.yml
+
+- name: run the std_include
+  include: /usr/share/ansible/openshift-ansible/playbooks/common/openshift-cluster/initialize_openshift_repos.yml
+
+- name: run node config setup
+  include: /usr/share/ansible/openshift-ansible/playbooks/common/openshift-node/setup.yml
+
+- name: run node config
+  include: /usr/share/ansible/openshift-ansible/playbooks/common/openshift-node/configure_nodes.yml
+
+- name: Re-enable excluders
+  include: /usr/share/ansible/openshift-ansible/playbooks/common/openshift-node/enable_excluders.yml
+
+- name: Commit image
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Terminate the image build instance
+      gce:
+        service_account_email: "{{ (lookup('file', openshift_gcp_iam_service_account_keyfile ) | from_json ).client_email }}"
+        credentials_file: "{{ openshift_gcp_iam_service_account_keyfile }}"
+        project_id: "{{ openshift_gcp_project }}"
+        zone: "{{ openshift_gcp_zone }}"
+        instance_names: "{{ openshift_gcp_prefix }}build-image-instance"
+        state: absent
+    - name: Save the new image
+      command: gcloud --project "{{ openshift_gcp_project}}" compute images create "{{ openshift_gcp_image_name | default(openshift_gcp_image + '-' + lookup('pipe','date +%Y%m%d-%H%M%S')) }}" --source-disk "{{ openshift_gcp_prefix }}build-image-instance" --source-disk-zone "{{ openshift_gcp_zone }}" --family "{{ openshift_gcp_image }}"
+    - name: Remove the image instance disk
+      gce_pd:
+        service_account_email: "{{ (lookup('file', openshift_gcp_iam_service_account_keyfile ) | from_json ).client_email }}"
+        credentials_file: "{{ openshift_gcp_iam_service_account_keyfile }}"
+        project_id: "{{ openshift_gcp_project }}"
+        zone: "{{ openshift_gcp_zone }}"
+        name: "{{ openshift_gcp_prefix }}build-image-instance"
+        state: absent

--- a/playbooks/roles/custom-repositories/templates/yum_repo.j2
+++ b/playbooks/roles/custom-repositories/templates/yum_repo.j2
@@ -1,5 +1,5 @@
 {% for repo in provision_custom_repositories %}
-[{{ repo.id }}]
+[{{ repo.id | default(repo.name) }}]
 name={{ repo.name | default(repo.id) }}
 baseurl={{ repo.baseurl }}
 {% set enable_repo = repo.enabled | default(1) %}


### PR DESCRIPTION
Split image build into base and top

```
ansible-playbook playbooks/build_image.yaml \
     -e "openshift_gcp_image=origin-37-node" \
     -e "openshift_gcp_base_image=rhel-7" \
     -e openshift_test_repo=https://storage.googleapis.com/origin-ci-test/branch-logs/origin/master/builds/41/artifacts/rpms \
     -e "openshift-pkg-version=-3.7.0-0.alpha.1.859.5d7f1b8" \
     -e "skip_node_svc_handlers=true"
```